### PR TITLE
Minor fixes to digital coded exposure with streaming.

### DIFF
--- a/include/EventData.h
+++ b/include/EventData.h
@@ -197,6 +197,8 @@ class EventData {
 
         void setParticleTimeDensity(float _particleTimeDensity) { this->particleTimeDensity = _particleTimeDensity; }
         float getParticleTimeDensity() { return particleTimeDensity; }
+
+        void setIsStreaming(bool _isStreaming) { isStreaming = _isStreaming; }
         
         static inline int TIME_CONVERSION; 
         static const int TIME_SHUTTER = 0; // values must match ImGui::Combo order in utils.cpp
@@ -207,6 +209,8 @@ class EventData {
         float diffScale;
 
         float particleTimeDensity; // Density of particles along time axis
+
+        bool isStreaming; // Flag to indicate if data is being streamed
 
         // TODO: Might be better to just store a std::bitset for polarity, and something dynamic like a color
         // indicator for a (although we would need a vec3 for a full RGB)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,7 @@ static void streamEvtDataAndCamera() {
     int retVal{ g_eventData->streamParticlesFromFile(g_dataFilepath, g_maxZ * EventData::TIME_CONVERSION, g_pauseStream) };
     if (retVal == 1) // Indicates first time batch, need to set up camera
     {
+        g_eventData->setResourceDir(g_resourceDir);
         initCamera();
     }
 }
@@ -191,6 +192,9 @@ static void render() {
 
     // Update particle time density
     g_eventData->setParticleTimeDensity(g_particleTimeDensity);
+
+    // Update isStreaming
+    g_eventData->setIsStreaming(g_dataStreamed);
 
     g_mainSceneFBO.bind();
     glViewport(0, 0, width, height);


### PR DESCRIPTION
Ensures regular draw does not keep resending data to GPU. Fix digital coded exposure not working when user opens app and starts streaming immediately.